### PR TITLE
lisätty expo-kansio gitignoreen, backendin packageen pieni muutos, ko…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,7 @@ dist-ssr
 *.sln
 *.sw?
 
-
 .env
+
+# expo dir
+.expo/

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "generate-swagger": "swagger.js"
+    "generate-swagger": "swagger.js",
+    "start": "node index.js"
   },
   "keywords": [],
   "author": "",

--- a/sql/testdata.sql
+++ b/sql/testdata.sql
@@ -7,7 +7,7 @@ INSERT INTO users (firebaseuserid, username, usermail) VALUES
 ('OMhagDA6eVgpok70Z2ywj39yAMz1', 'Kan-Joni', 'rusina@munkki.net');
 
 -- Insert test items
-INSERT INTO items (giverid, itemname, itemdescription, itempicture, queretruepickfalse, postalcode, city) VALUES 
+INSERT INTO items (giverid, itemname, itemdescription, itempicture, queuetruepickfalse, postalcode, city) VALUES 
 (1, 'Hamsu -kirja', 'Käytetyssä kunnossa, kirja hamsterin hoidosta', 'book.jpg', TRUE, '00100', 'Helsinki'),
 (2, 'Tuolit 6kpl', 'Keittiön pöydät, 6kpl, pinta rispaantunut muutamassa, muuten hyvä kunto!', 'chair.jpg', FALSE, '00200', 'Espoo'),
 (3, 'Työpöytä', 'Pienikokoinen työpöytä, koko 60x100 cm, tästä vaikka etätyöskentelyyn. Näppärä, ei keiku', 'table.jpg', TRUE, '00300', 'Tampere');


### PR DESCRIPTION
…rjaus testidataan

**Tässä pr:ssä:** 
- expo dir lisätty gitignoreen
- korjattu typo tietokannan testidatasta myös, niin menee datat sisään
- packageen pieni muutos, jolla: 
  - voi ajella backendista serverin käyntiin "npm start" -komennolla
  - jos haluat ajella serveriä ja saada dataa ulos, nyt esim saa itemeitä + voi postata itemeitä, niin:
    - toimiva kanta löytyy renderistä
    - serverillä auth -reitit ok ja item -reitit työn alla: ne alkaa olla ok 
    - envi päivitettävä, voin jakaa Discissä renderisalaisuudet 


![image](https://github.com/user-attachments/assets/271a6ab4-7dd4-4522-945d-db5710199063)

![image](https://github.com/user-attachments/assets/fe50f561-d72a-4b16-a275-0def5d314c54)

![image](https://github.com/user-attachments/assets/c68c5cf4-d979-4971-b0c4-7bb8b4d68520)

![image](https://github.com/user-attachments/assets/06692094-968c-4682-8280-db14014eee8f)
