### PR TITLE
Implementoitu viestittelyyn tarvittavat näkymät, komponentit ja logiikka

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -17,6 +17,7 @@ import MessagesMain from './screens/messages/MessagesMain';
 import { ItemsFromThisUser, QueuesOfThisUser, ItemAddView } from './screens/items/ItemComponents';
 import * as ScreenOrientation from 'expo-screen-orientation';
 import Toast from 'react-native-toast-message';
+import ChatView from './screens/chat/ChatView';
 
 const Stack = createStackNavigator();
 
@@ -62,6 +63,7 @@ export default function App() {
                 <Stack.Screen name="AccountMaintain" component={AccountMaintain} options={{ headerShown: false }} />
                 <Stack.Screen name="MyItems" component={ItemsFromThisUser} options={{ headerShown: false }} />
                 <Stack.Screen name="MyQueues" component={QueuesOfThisUser} options={{ headerShown: false }} />
+                <Stack.Screen name="Chat" component={ChatView} options={{ headerShown: false }}/>
               </Stack.Navigator>
             </View>
           <CustomBottomBar />

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@react-navigation/native": "^6.1.18",
     "@react-navigation/stack": "^6.4.1",
     "axios": "^1.7.7",
+    "date-fns": "^4.1.0",
     "emulator": "^0.1.0",
     "expo": "^52.0.4",
     "expo-location": "18.0.1",

--- a/frontend/screens/chat/ChatView.js
+++ b/frontend/screens/chat/ChatView.js
@@ -1,0 +1,137 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, StyleSheet, FlatList, TextInput, TouchableOpacity, KeyboardAvoidingView, Platform } from 'react-native';
+import { firestore } from '../../services/firebaseConfig';
+import { collection, addDoc, query, orderBy, onSnapshot, serverTimestamp, doc } from 'firebase/firestore';
+
+const ChatView = ({ route }) => {
+  const { threadId } = route.params;
+  const [messages, setMessages] = useState([]);
+  const [newMessage, setNewMessage] = useState('');
+
+  // replace with actual user id
+  const sampleUserId = "CzmNeYO7av152mqA9SHY";
+
+  useEffect(() => {
+    const messagesRef = collection(firestore, 'threadstest', threadId, 'messages');
+    const q = query(messagesRef, orderBy('createdAt', 'asc'));
+
+    const unsubscribe = onSnapshot(q, (snapshot) => {
+      const messagesData = snapshot.docs.map(doc => ({
+        id: doc.id,
+        ...doc.data(),
+      }));
+      setMessages(messagesData);
+    });
+
+    return () => unsubscribe();
+  }, [threadId]);
+
+  const sendMessage = async () => {
+    if (newMessage.trim() === '') return;
+
+    try {
+      const messagesRef = collection(firestore, 'threadstest', threadId, 'messages');
+      const userRef = doc(firestore, 'users', sampleUserId);
+      
+      await addDoc(messagesRef, {
+        content: newMessage,
+        sender: userRef,
+        createdAt: serverTimestamp(),
+      });
+      setNewMessage('');
+    } catch (error) {
+      console.error('Error sending message:', error);
+    }
+  };
+
+  const renderItem = ({ item }) => {
+    const isCurrentUser = item.sender.id === sampleUserId;
+    return (
+      <View style={[styles.messageContainer, isCurrentUser ? styles.currentUser : styles.otherUser]}>
+        <Text style={styles.messageText}>{item.content}</Text>
+      </View>
+    );
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={80}
+    >
+      <FlatList
+        data={messages}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        contentContainerStyle={styles.chatContainer}
+      />
+      <View style={styles.inputContainer}>
+        <TextInput
+          style={styles.textInput}
+          placeholder="Kirjoita viesti..."
+          value={newMessage}
+          onChangeText={setNewMessage}
+        />
+        <TouchableOpacity style={styles.sendButton} onPress={sendMessage}>
+          <Text style={styles.sendButtonText}>Lähetä</Text>
+        </TouchableOpacity>
+      </View>
+    </KeyboardAvoidingView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  chatContainer: {
+    padding: 16,
+  },
+  messageContainer: {
+    marginVertical: 8,
+    padding: 10,
+    borderRadius: 10,
+    maxWidth: '75%',
+  },
+  currentUser: {
+    alignSelf: 'flex-end',
+    backgroundColor: '#DCF8C6',
+  },
+  otherUser: {
+    alignSelf: 'flex-start',
+    backgroundColor: '#E4E6EB',
+  },
+  messageText: {
+    fontSize: 16,
+  },
+  inputContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 16,
+    borderTopWidth: 1,
+    borderColor: '#ddd',
+    backgroundColor: '#fff',
+    marginBottom: 8,
+  },
+  textInput: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 25,
+    padding: 10,
+    fontSize: 16,
+    marginRight: 10,
+  },
+  sendButton: {
+    backgroundColor: '#007BFF',
+    borderRadius: 25,
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+  },
+  sendButtonText: {
+    color: '#fff',
+    fontSize: 16,
+  },
+});
+
+export default ChatView;

--- a/frontend/screens/messages/MessagesMain.js
+++ b/frontend/screens/messages/MessagesMain.js
@@ -1,65 +1,112 @@
-import React, { useContext, useState, useEffect } from 'react';
-import { ScrollView, Text, StyleSheet, View } from 'react-native';
-import { Heading, BasicSection } from '../../components/CommonComponents';
-import { AuthenticationContext } from '../../services/auth';
-import { firestore } from '../../services/firebaseConfig';
-import { doc, onSnapshot, query, where, collection, getDoc, getDocs, orderBy, limit } from 'firebase/firestore';
-import ThreadCard from './ThreadCard';
+import React, { useContext, useState, useEffect } from "react";
+import { ScrollView, Text, StyleSheet, View } from "react-native";
+import { Heading, BasicSection } from "../../components/CommonComponents";
+import { AuthenticationContext } from "../../services/auth";
+import { firestore } from "../../services/firebaseConfig";
+import {
+  doc,
+  onSnapshot,
+  query,
+  where,
+  collection,
+  getDoc,
+  getDocs,
+  orderBy,
+  limit,
+} from "firebase/firestore";
+import ThreadCard from "./ThreadCard";
 
 const MessagesMain = () => {
-    // const {authState} = useContext(AuthenticationContext);
-    const [threads, setThreads] = useState([]);
-    const sampleUserId = "CzmNeYO7av152mqA9SHY"
+  // const {authState} = useContext(AuthenticationContext);
+  const [threads, setThreads] = useState([]);
+  const sampleUserId = "CzmNeYO7av152mqA9SHY";
 
-    useEffect(() => {
-        const threadsRef = collection(firestore, "threadstest");
-        const userRef = doc(firestore, "users", sampleUserId);
+  useEffect(() => {
+    const threadsRef = collection(firestore, "threadstest");
+    const userRef = doc(firestore, "users", sampleUserId);
 
-        const q = query(threadsRef, where('participants', 'array-contains', userRef));
-        const unsubscribe = onSnapshot(q, (snapshot) => {
-            const threadsData = snapshot.docs.map(doc => ({
-                id: doc.id,
-                ...doc.data()
-            }));
+    const q = query(
+      threadsRef,
+      where("participants", "array-contains", userRef)
+    );
+    const unsubscribe = onSnapshot(q, async (snapshot) => {
+      const threadsData = await Promise.all(
+        snapshot.docs.map(async (docSnap) => {
+          const thread = docSnap.data();
+          const threadId = docSnap.id;
 
-            setThreads(threadsData); 
-        });
+          const messagesRef = collection(
+            firestore,
+            "threadstest",
+            threadId,
+            "messages"
+          );
+          const messageQuery = query(
+            messagesRef,
+            orderBy("createdAt", "desc"),
+            limit(1)
+          );
+          const messageSnapshot = await getDocs(messageQuery);
 
-        return () => unsubscribe();
-    }, []);
+          let latestMessage = null;
+          if (!messageSnapshot.empty) {
+            latestMessage = messageSnapshot.docs[0].data();
+          }
 
-    return (
-        <View style={styles.container}>
-        <Heading title="Omat keskustelut" />
+          return {
+            ...thread,
+            id: threadId,
+            latestMessage,
+          };
+        })
+      );
 
-        <ScrollView style={styles.scrollContainer}>
+      const sortedThreads = threadsData.sort((a, b) => {
+        if (!a.latestMessage || !b.latestMessage) return 0;
+        return (
+          b.latestMessage.createdAt.seconds - a.latestMessage.createdAt.seconds
+        );
+      });
+
+      setThreads(sortedThreads);
+    });
+
+    return () => unsubscribe();
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <Heading title="Omat keskustelut" />
+
+      <ScrollView style={styles.scrollContainer}>
         {threads.length > 0 ? (
-          threads.map(thread => (
+          threads.map((thread) => (
             <ThreadCard key={thread.id} thread={thread} />
           ))
         ) : (
-          <Text style={styles.noThreadsText}>Aktiivisia keskusteluja ei löytynyt</Text>
+          <Text style={styles.noThreadsText}>
+            Aktiivisia keskusteluja ei löytynyt
+          </Text>
         )}
       </ScrollView>
-
     </View>
-    );
+  );
 };
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     paddingTop: 20,
-    backgroundColor: '#f0f0f0',
+    backgroundColor: "#f0f0f0",
   },
   scrollContainer: {
     paddingHorizontal: 8,
     paddingBottom: 16,
   },
   noThreadsText: {
-    textAlign: 'center',
+    textAlign: "center",
     marginTop: 20,
-    color: '#888',
+    color: "#888",
     fontSize: 16,
   },
 });

--- a/frontend/screens/messages/MessagesMain.js
+++ b/frontend/screens/messages/MessagesMain.js
@@ -1,22 +1,48 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import { ScrollView, Text} from 'react-native';
 import { Heading, BasicSection } from '../../components/CommonComponents';
 import { AuthenticationContext } from '../../services/auth';
+import { firestore } from '../../services/firebaseConfig';
+import { doc, onSnapshot, query, where, collection } from 'firebase/firestore';
 
 const MessagesMain = () => {
-    const {authState} = useContext(AuthenticationContext);
+    // const {authState} = useContext(AuthenticationContext);
+    const [threads, setThreads] = useState([]);
+    const sampleUserId = "2vpqcqFcuHNJvhJOldR2"
 
+    useEffect(() => {
+        const threadsRef = collection(firestore, "threadstest");
+        const userRef = doc(firestore, "users", sampleUserId);
 
-    if (!authState) {
-      return <Text>No user data found.</Text>;
-    }
+        const q = query(threadsRef, where('participants', 'array-contains', userRef));
+        const unsubscribe = onSnapshot(q, (snapshot) => {
+            const threadsData = snapshot.docs.map(doc => ({
+                id: doc.id,
+                ...doc.data()
+            }));
+
+            setThreads(threadsData); 
+        });
+
+        return () => unsubscribe();
+    }, []);
+
+    useEffect(() => {
+        console.log(threads);
+    }, [threads]);
 
     return (
         <ScrollView contentContainerStyle={{ padding: 8 }}>
             <Heading title="Omat keskustelut" />
 
             <BasicSection>
-                Tähän käyttäjän aktiiviset keskustelut
+                {threads.length > 0 ? (
+                    threads.map(thread => (
+                        <Text key={thread.id}>{thread.id}{"\n"}</Text>
+                    ))
+                ) : (
+                    <Text>Aktiivisia keskusteluja ei löytynyt</Text>
+                )}
             </BasicSection>
 
         </ScrollView>

--- a/frontend/screens/messages/MessagesMain.js
+++ b/frontend/screens/messages/MessagesMain.js
@@ -1,14 +1,15 @@
 import React, { useContext, useState, useEffect } from 'react';
-import { ScrollView, Text} from 'react-native';
+import { ScrollView, Text, StyleSheet, View } from 'react-native';
 import { Heading, BasicSection } from '../../components/CommonComponents';
 import { AuthenticationContext } from '../../services/auth';
 import { firestore } from '../../services/firebaseConfig';
-import { doc, onSnapshot, query, where, collection } from 'firebase/firestore';
+import { doc, onSnapshot, query, where, collection, getDoc, getDocs, orderBy, limit } from 'firebase/firestore';
+import ThreadCard from './ThreadCard';
 
 const MessagesMain = () => {
     // const {authState} = useContext(AuthenticationContext);
     const [threads, setThreads] = useState([]);
-    const sampleUserId = "2vpqcqFcuHNJvhJOldR2"
+    const sampleUserId = "CzmNeYO7av152mqA9SHY"
 
     useEffect(() => {
         const threadsRef = collection(firestore, "threadstest");
@@ -27,26 +28,40 @@ const MessagesMain = () => {
         return () => unsubscribe();
     }, []);
 
-    useEffect(() => {
-        console.log(threads);
-    }, [threads]);
-
     return (
-        <ScrollView contentContainerStyle={{ padding: 8 }}>
-            <Heading title="Omat keskustelut" />
+        <View style={styles.container}>
+        <Heading title="Omat keskustelut" />
 
-            <BasicSection>
-                {threads.length > 0 ? (
-                    threads.map(thread => (
-                        <Text key={thread.id}>{thread.id}{"\n"}</Text>
-                    ))
-                ) : (
-                    <Text>Aktiivisia keskusteluja ei löytynyt</Text>
-                )}
-            </BasicSection>
+        <ScrollView style={styles.scrollContainer}>
+        {threads.length > 0 ? (
+          threads.map(thread => (
+            <ThreadCard key={thread.id} thread={thread} />
+          ))
+        ) : (
+          <Text style={styles.noThreadsText}>Aktiivisia keskusteluja ei löytynyt</Text>
+        )}
+      </ScrollView>
 
-        </ScrollView>
+    </View>
     );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 20,
+    backgroundColor: '#f0f0f0',
+  },
+  scrollContainer: {
+    paddingHorizontal: 8,
+    paddingBottom: 16,
+  },
+  noThreadsText: {
+    textAlign: 'center',
+    marginTop: 20,
+    color: '#888',
+    fontSize: 16,
+  },
+});
 
 export default MessagesMain;

--- a/frontend/screens/messages/ThreadCard.js
+++ b/frontend/screens/messages/ThreadCard.js
@@ -1,0 +1,111 @@
+import React, { useContext, useState, useEffect } from 'react';
+import { ScrollView, Text, StyleSheet, View } from 'react-native';
+import { Heading, BasicSection } from '../../components/CommonComponents';
+import { AuthenticationContext } from '../../services/auth';
+import { firestore } from '../../services/firebaseConfig';
+import { doc, query, where, collection, getDoc, getDocs, orderBy, limit } from 'firebase/firestore';
+
+const ThreadCard = ({ thread }) => {
+  const [itemName, setItemName] = useState('');
+  const [participants, setParticipants] = useState([]);
+  const [latestMessage, setLatestMessage] = useState('');
+
+  const authState = {
+    user: {
+      id: "CzmNeYO7av152mqA9SHY",
+      username: "testuser",
+    },
+  }
+
+  useEffect(() => {
+    // fetch item name
+    const fetchItemName = async () => {      
+      const itemRef = doc(firestore, 'items', thread.item.id);
+      const itemSnap = await getDoc(itemRef);
+      if (itemSnap.exists()) {
+        setItemName(itemSnap.data().itemname);
+      }
+    };
+
+    // fetch participant usernames
+    const fetchParticipants = async () => {
+      const participants = await Promise.all(
+        thread.participants.map(async (participantRef) => {
+          const userSnap = await getDoc(participantRef);
+          return userSnap.exists() ? {
+            id: userSnap.id,
+            ...userSnap.data(),
+          } : {};
+        })
+      );
+      setParticipants(participants);
+      
+    };
+
+    // fetch latest message from the "messages" subcollection
+    const fetchLatestMessage = async () => {
+      const messagesRef = collection(firestore, 'threadstest', thread.id, 'messages');
+      
+      const q = query(messagesRef, orderBy('createdAt', 'desc'), limit(1));
+      const querySnapshot = await getDocs(q);
+      
+      
+      if (!querySnapshot.empty) {
+        const latestMessageData = querySnapshot.docs[0].data();
+        setLatestMessage(latestMessageData);
+      }
+    };
+
+    fetchItemName();
+    fetchParticipants();
+    fetchLatestMessage();
+  }, []);
+  
+  return (
+    <View style={styles.card}>
+      <View style={styles.cardHeader}>
+        <Text style={styles.itemName}>{itemName}</Text>
+        <Text style={styles.participants}>{participants.find(p => p.id !== authState.user.id)?.username}</Text>
+      </View>
+      <Text style={styles.latestMessage}>
+        {latestMessage.sender?.id === authState.user.id ? 'You: ' : participants.find(p => p.id === latestMessage.sender.id)?.username + ': '}
+        {latestMessage.content || 'Ei viestejä'}
+      </Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    padding: 16,
+    marginBottom: 10,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+  cardHeader: {
+    marginBottom: 8,
+  },
+  itemName: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: '#333',
+  },
+  participants: {
+    fontSize: 14,
+    color: '#777',
+    marginTop: 4,
+  },
+  latestMessage: {
+    fontSize: 14,
+    color: '#888',
+    marginTop: 8,
+    fontStyle: 'italic',
+  },
+});
+
+export default ThreadCard;

--- a/frontend/screens/messages/ThreadCard.js
+++ b/frontend/screens/messages/ThreadCard.js
@@ -1,15 +1,31 @@
-import React, { useContext, useState, useEffect } from 'react';
-import { ScrollView, Text, StyleSheet, View } from 'react-native';
-import { Heading, BasicSection } from '../../components/CommonComponents';
-import { AuthenticationContext } from '../../services/auth';
-import { firestore } from '../../services/firebaseConfig';
-import { doc, query, where, collection, getDoc, getDocs, orderBy, limit } from 'firebase/firestore';
-import { formatDistanceToNow } from 'date-fns';
+import React, { useContext, useState, useEffect } from "react";
+import {
+  ScrollView,
+  Text,
+  StyleSheet,
+  View,
+  TouchableOpacity,
+} from "react-native";
+import { Heading, BasicSection } from "../../components/CommonComponents";
+import { AuthenticationContext } from "../../services/auth";
+import { firestore } from "../../services/firebaseConfig";
+import {
+  doc,
+  query,
+  where,
+  collection,
+  getDoc,
+  getDocs,
+  orderBy,
+  limit,
+} from "firebase/firestore";
+import { formatDistanceToNow } from "date-fns";
+import { useNavigation } from "@react-navigation/native";
 
 const ThreadCard = ({ thread }) => {
-  const [itemName, setItemName] = useState('');
+  const [itemName, setItemName] = useState("");
   const [participants, setParticipants] = useState([]);
-  const [latestMessage, setLatestMessage] = useState('');
+  const navigation = useNavigation();
 
   // sample authState for testing
   const authState = {
@@ -17,12 +33,11 @@ const ThreadCard = ({ thread }) => {
       id: "CzmNeYO7av152mqA9SHY",
       username: "testuser",
     },
-  }
+  };
 
   useEffect(() => {
-    // fetch item name
-    const fetchItemName = async () => {      
-      const itemRef = doc(firestore, 'items', thread.item.id);
+    const fetchItemName = async () => {
+      const itemRef = doc(firestore, "items", thread.item.id);
       const itemSnap = await getDoc(itemRef);
       if (itemSnap.exists()) {
         setItemName(itemSnap.data().itemname);
@@ -34,68 +49,63 @@ const ThreadCard = ({ thread }) => {
       const participants = await Promise.all(
         thread.participants.map(async (participantRef) => {
           const userSnap = await getDoc(participantRef);
-          return userSnap.exists() ? {
-            id: userSnap.id,
-            ...userSnap.data(),
-          } : {};
+          return userSnap.exists()
+            ? {
+                id: userSnap.id,
+                ...userSnap.data(),
+              }
+            : {};
         })
       );
       setParticipants(participants);
-      
-    };
-
-    // fetch latest message from "messages" subcollection
-    const fetchLatestMessage = async () => {
-      const messagesRef = collection(firestore, 'threadstest', thread.id, 'messages');
-      const q = query(messagesRef, orderBy('createdAt', 'desc'), limit(1));
-      const querySnapshot = await getDocs(q);
-      
-      if (!querySnapshot.empty) {
-        const latestMessageData = querySnapshot.docs[0].data();
-        setLatestMessage(latestMessageData);
-      }
     };
 
     fetchItemName();
     fetchParticipants();
-    fetchLatestMessage();
   }, []);
 
   const formatTimestamp = (timestamp) => {
-        return formatDistanceToNow(timestamp.toDate(), { addSuffix: true });
+    return formatDistanceToNow(timestamp.toDate(), { addSuffix: true });
   };
-  
-  return (
-    <View style={styles.card}>
-      <View style={styles.cardHeader}>
-        <Text style={styles.itemName}>{itemName}</Text>
-        <Text style={styles.participants}>{participants.find(p => p.id !== authState.user.id)?.username}</Text>
-      </View>
-      <View style={styles.messageContainer}>
-        <Text style={styles.latestMessage}>
-          {latestMessage?.sender?.id === authState.user.id
-            ? 'Sinä: '
-            : participants.find(p => p.id === latestMessage?.sender.id)?.username + ': '}
-          {latestMessage?.content || 'Ei viestejä'}
-        </Text>
 
-        {latestMessage && latestMessage.createdAt && (
-          <Text style={styles.timestamp}>
-            {formatTimestamp(latestMessage.createdAt)}
+  return (
+    <TouchableOpacity
+      onPress={() => navigation.navigate("Chat", { threadId: thread.id })}
+    >
+      <View style={styles.card}>
+        <View style={styles.cardHeader}>
+          <Text style={styles.itemName}>{itemName}</Text>
+          <Text style={styles.participants}>
+            {participants.find((p) => p.id !== authState.user.id)?.username}
           </Text>
-        )}
+        </View>
+        <View style={styles.messageContainer}>
+          <Text style={styles.latestMessage}>
+            {thread.latestMessage?.sender?.id === authState.user.id
+              ? "Sinä: "
+              : participants.find(
+                  (p) => p.id === thread.latestMessage?.sender.id
+                )?.username + ": "}
+            {thread.latestMessage?.content || "Ei viestejä"}
+          </Text>
+          {thread.latestMessage && thread.latestMessage.createdAt && (
+            <Text style={styles.timestamp}>
+              {formatTimestamp(thread.latestMessage.createdAt)}
+            </Text>
+          )}
+        </View>
       </View>
-    </View>
+    </TouchableOpacity>
   );
 };
 
 const styles = StyleSheet.create({
   card: {
-    backgroundColor: '#fff',
+    backgroundColor: "#fff",
     borderRadius: 8,
     padding: 16,
     marginBottom: 10,
-    shadowColor: '#000',
+    shadowColor: "#000",
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.25,
     shadowRadius: 4,
@@ -106,29 +116,29 @@ const styles = StyleSheet.create({
   },
   itemName: {
     fontSize: 18,
-    fontWeight: 'bold',
-    color: '#333',
+    fontWeight: "bold",
+    color: "#333",
   },
   participants: {
     fontSize: 14,
-    color: '#777',
+    color: "#777",
     marginTop: 4,
   },
-    messageContainer: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+  messageContainer: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
     marginTop: 8,
   },
   latestMessage: {
     fontSize: 14,
-    color: '#888',
+    color: "#888",
     flex: 1,
-    fontStyle: 'italic',
+    fontStyle: "italic",
   },
   timestamp: {
     fontSize: 12,
-    color: '#aaa',
+    color: "#aaa",
     marginLeft: 8,
   },
 });


### PR DESCRIPTION
#31 Käyttäjä pääsee nyt näkemään, selaamaan ja avaamaan omat aktiiviset viestikeskustelut

MessagesMain nyt hakee tietokannasta aktiiviset keskustelut ja listaa ne käyttäjälle. Klikkaamalla listassa olevaa korttia käyttäjä voi avata keskustelu-näkymän ja lähettää viestejä 

![image](https://github.com/user-attachments/assets/4d128521-1f78-42ff-824d-adee81ee938b)
![image](https://github.com/user-attachments/assets/223b8d8f-c472-455b-aee3-23a8630764f8)
