### PR TITLE
Expirationit: varaukset ja julkaisut

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -36,7 +36,7 @@ const AppNavigator = () => {
   const authState = useContext(AuthenticationContext);
 
   return (
-    <Stack.Navigator initialRouteName="Home">
+    <Stack.Navigator initialRouteName="AuthScreen">
       {authState ? (
         // User authenticated
         <>

--- a/frontend/screens/items/ItemsMain.js
+++ b/frontend/screens/items/ItemsMain.js
@@ -10,8 +10,10 @@ import { ItemQueues } from './ItemQueues';
 import Icon from 'react-native-vector-icons/Ionicons';
 import globalStyles from '../../assets/styles/Styles';
 import { deleteExpiredStuff } from '../../services/firestoreQueues';
+import { deleteExpiredItems } from '../../services/firestoreItems';
 
 const ItemsMain = () => {
+  deleteExpiredItems();
   deleteExpiredStuff();
 
   const navigation = useNavigation(); 

--- a/frontend/services/firestoreItems.js
+++ b/frontend/services/firestoreItems.js
@@ -188,15 +188,15 @@ import { Timestamp } from 'firebase/firestore';
             throw error;
         }
     }
-    
+        
     const deleteSubcollection = async (parentRef, subcollectionName) => {
         try {
             const subcollectionRef = collection(parentRef, subcollectionName);
             const snapshot = await getDocs(subcollectionRef);
-    
+
             for (const docSnapshot of snapshot.docs) {
                 await deleteDoc(docSnapshot.ref);
-                console.log(`Poistettu dokumentti ${subcollectionName} alikokoelmasta: ${docSnapshot.id}`);
+                console.log(`Poistettu ${subcollectionName} alikokoelmasta: ${docSnapshot.id}`);
             }
         } catch (error) {
             console.error(`Virhe poistettaessa ${subcollectionName} alikokoelmaa:`, error);

--- a/frontend/services/firestoreUsers.js
+++ b/frontend/services/firestoreUsers.js
@@ -7,10 +7,9 @@ import {
     deleteDoc, 
     doc,
     setDoc,
-    getDoc
+    getDoc,
+    collectionGroup
 } from 'firebase/firestore';
-
-import { getAuth } from 'firebase/auth';
 import { firestore } from './firebaseConfig'; 
 import { get, last, take } from 'lodash';
 
@@ -52,47 +51,44 @@ import { get, last, take } from 'lodash';
     };
 
     export const deleteUserDataFromFirestore = async (uid) => {
-        try {
-          const collectionsToClean = ["items", "users"];
-
-          for (const collectionName of collectionsToClean) {
-            const userRef = collection(firestore, collectionName);
-            const giverRef = doc(firestore, "users", uid);
-
-            const giveridQuery = query(userRef, where("giverid", "==", giverRef));
-            const uidQuery = query(userRef, where("uid", "==", uid));
-
-            const giveridSnapshot = await getDocs(giveridQuery);
-            const uidSnapshot = await getDocs(uidQuery);
-
-            for (const doc of giveridSnapshot.docs) {
-              const itemRef = doc.ref;
-              const takersRef = collection(itemRef, "takers");
-
-              const takersSnapshot = await getDocs(takersRef);
-              for (const takerDoc of takersSnapshot.docs) {
-                await deleteDoc(takerDoc.ref);
-                console.log(`Taker ${takerDoc.id} poistettu tuotteesta ${doc.id}`);
+      try {
+          const userRef = doc(firestore, "users", uid);
+          const itemsRef = collection(firestore, 'items');
+  
+          // Poistetaan käyttäjän julkaisut + julkaisun varaajat 
+          const userItemsQuery = query(itemsRef, where('giverid', '==', userRef));
+          const userItemsSnapshot = await getDocs(userItemsQuery);
+  
+          for (const itemDoc of userItemsSnapshot.docs) {
+              const itemTakersRef = collection(itemDoc.ref, 'takers');
+              const itemTakersSnapshot = await getDocs(itemTakersRef);
+  
+              for (const takerDoc of itemTakersSnapshot.docs) {
+                  await deleteDoc(takerDoc.ref);
+                  console.log(`Poistettu tuotteen ${itemDoc.id} varaaja: ${takerDoc.id}`);
               }
-
-              const takeridQuery = query(takersRef, where("takerid", "==", uid));
-              const takeridSnapshot = await getDocs(takeridQuery);
-              for (const takerDoc of takeridSnapshot.docs) {
-                await deleteDoc(takerDoc.ref);
-                console.log(`Rivi ${takerDoc.id} poistettu kokoelmasta takers (takerid-ehto)`);
-              }
-
-              await deleteDoc(itemRef);
-              console.log(`Rivi ${doc.id} poistettu kokoelmasta ${collectionName} (giverid-ehto)`);
-            }
-
-            for (const doc of uidSnapshot.docs) {
-              await deleteDoc(doc.ref);
-              console.log(`Rivi ${doc.id} poistettu kokoelmasta ${collectionName} (uid-ehto)`);
-            }
+  
+              await deleteDoc(itemDoc.ref);
+              console.log(`Poistettu käyttäjän ${uid} tuote: ${itemDoc.id}`);
           }
-        } catch (error) {
-          console.error("Virhe käyttäjän tietojen poistossa Firestoresta:", error);
+  
+          // Poistaa käyttäjän omat varaukset
+          const takersRef = collectionGroup(firestore, 'takers');
+          const q = query(takersRef, where("takerId", "==", userRef));
+          const snapshot = await getDocs(q);
+
+          for (const queueDoc of snapshot.docs) {
+              await deleteDoc(queueDoc.ref);
+              console.log(`Poistettu käyttäjän ${uid} varaus: ${queueDoc.id}`);
+          }
+          
+          // Poistaa käyttäjän dokumentin
+          await deleteDoc(userRef);
+          console.log(`Käyttäjä ${uid} poistettu Firestoresta`); 
+
+      } catch (error) {
+          console.error('Poistovirhe:', error);
           throw error;
-        }
-      };
+      }
+  };
+  


### PR DESCRIPTION
## Varausten voimassaoloaikaa parannettu:
#72 
- Kun käyttäjä tekee varauksen: 
  - varaus on voimassa 6h edellisen varaajan expirationista 
  - jos varaajaa ei ole, niin 6h nykyhetkestä

_Jatkokehitykseen update, jossa päivitetään expiration time suhteessa edelliseen voimassa olevaan ja siitä 6h (välistä lähtevät varaukset) ja ei päivitetä mitään, jos varaus on ensimmäisellä sijalla eikä edellistä varausta ole._


## Ilmoitusten voimassaoloaika:
#73 
- Ilmoitukset voimassa 1 viikon julkaisusta, jos käyttäjä ei poista itemiään
  - Jos ilmoitus vanhenee, poistetaan se ja alikokoelma takers samalla
- Kun käyttäjä poistaa ilmoituksen itse, poistetaan alikokoelma takers samalla



## Käyttäjän tietojen poisto firestoresta, kun käyttäjä poistuu palvelusta:
 #52 
- Kun käyttäjä poistaa tilinsä, niin tapahtuu: 
  - Alikokoelma takers poistetaan käyttäjän julkaisuista
  - Käyttäjän julkaisut poistetaan
  - Käyttäjän omat varaukset poistetaan
  - Käyttäjä poistetaan firestoresta
  - Käyttäjän autentikointitili poistetaan firebasesta
 